### PR TITLE
catch errors in findEvents() in MarkupGoogleCalendar.module

### DIFF
--- a/MarkupGoogleCalendar.module
+++ b/MarkupGoogleCalendar.module
@@ -297,9 +297,18 @@ class MarkupGoogleCalendar extends WireData implements Module {
 		);
 		
 		$options = array_merge($defaults, $options);
-		$calendarID = isset($options['calendarID']) ? $options['calendarID'] : $this->calendarID; 
-		$events = $google->calendar($calendarID)->getEvents($options);
-		
+
+
+		try {
+			// make request to the Google Calendar API
+			$calendarID = isset($options['calendarID']) ? $options['calendarID'] : $this->calendarID; 
+			$events = $google->calendar($calendarID)->getEvents($options);
+
+		} catch (\Exception $e) {
+			// handle errors
+			$events = $e->getMessage();
+		}
+
 		return $events;
 	}
 


### PR DESCRIPTION
I found errors on API calls are stopping following script execution - with try catch we can handle the response accordingly.